### PR TITLE
update bundle

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ipfs-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/cluster.ipfs.io_ipfsclusters.yaml
+++ b/bundle/manifests/cluster.ipfs.io_ipfsclusters.yaml
@@ -32,10 +32,19 @@ spec:
           metadata:
             type: object
           spec:
+            description: IpfsClusterSpec defines the desired state of the IpfsCluster.
             properties:
               clusterStorage:
-                type: string
+                anyOf:
+                - type: integer
+                - type: string
+                description: clusterStorage defines the amount of storage to be used
+                  by IPFS Cluster.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               follows:
+                description: follows defines the list of other IPFS Clusters this
+                  one should follow.
                 items:
                   properties:
                     name:
@@ -47,13 +56,45 @@ spec:
                   - template
                   type: object
                 type: array
+              ipfsResources:
+                description: ipfsResources specifies the resource requirements for
+                  each IPFS container. If this value is omitted, then the operator
+                  will automatically determine these settings based on the storage
+                  sizes used.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
               ipfsStorage:
                 anyOf:
                 - type: integer
                 - type: string
+                description: ipfsStorage defines the total storage to be allocated
+                  by this resource.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               networking:
+                description: networking defines network configuration settings.
                 properties:
                   circuitRelays:
                     format: int32
@@ -62,12 +103,16 @@ spec:
                 - circuitRelays
                 type: object
               public:
+                description: public determines whether or not we should be exposing
+                  this IPFS Cluster to the public.
                 type: boolean
               replicas:
+                description: replicas sets the number of replicas of IPFS Cluster
+                  nodes we should be running.
                 format: int32
                 type: integer
               reprovider:
-                description: Reprovider Describes the settings that each IPFS node
+                description: reprovider Describes the settings that each IPFS node
                   should use when reproviding content.
                 properties:
                   interval:
@@ -84,6 +129,7 @@ spec:
                     type: string
                 type: object
               url:
+                description: url defines the URL to be using as an ingress controller.
                 type: string
             required:
             - clusterStorage

--- a/bundle/manifests/ipfs-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ipfs-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-unknown
+    operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: ipfs-operator.v0.0.1
   namespace: placeholder
@@ -259,7 +259,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: coryschwartz/ipfs-operator:v0.0.1
+                image: quay.io/redhat-et-ipfs/ipfs-operator:v0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ipfs-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-unknown
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,4 +12,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: coryschwartz/ipfs-operator
+  newName: quay.io/redhat-et-ipfs/ipfs-operator


### PR DESCRIPTION
Some of the images were using `coryschwartz/ipfs-operator`, so this PR reverts them to use `redhat-et/ipfs-operator`.

Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>